### PR TITLE
use MHD_create_response_from_buffer instead of deprecated MHD_create_response_from_data

### DIFF
--- a/hello.c
+++ b/hello.c
@@ -18,7 +18,7 @@ static int ahc_echo(void * cls,
                     void ** ptr) {
   static int dummy;
   const char * page = cls;
-  struct MHD_Response * response;
+  struct MHD_Response * response = NULL;
   int ret;
 
   if (0 != strcmp(method, "GET"))
@@ -33,10 +33,11 @@ static int ahc_echo(void * cls,
   if (0 != *upload_data_size)
     return MHD_NO; /* upload data in a GET!? */
   *ptr = NULL; /* clear context pointer */
-  response = MHD_create_response_from_data(strlen(page),
-					   (void*) page,
-					   MHD_NO,
-					   MHD_NO);
+
+  response = MHD_create_response_from_buffer(strlen(page),
+                                             (void *) page,
+                                             MHD_RESPMEM_PERSISTENT);
+
   ret = MHD_queue_response(connection,
 			   MHD_HTTP_OK,
 			   response);

--- a/hello.c
+++ b/hello.c
@@ -33,7 +33,6 @@ static int ahc_echo(void * cls,
   if (0 != *upload_data_size)
     return MHD_NO; /* upload data in a GET!? */
   *ptr = NULL; /* clear context pointer */
-
   response = MHD_create_response_from_buffer(strlen(page),
                                              (void *) page,
                                              MHD_RESPMEM_PERSISTENT);


### PR DESCRIPTION
`MHD_create_response_from_data ` is deprecated.

use `MHD_create_response_from_buffer` instead of deprecated `MHD_create_response_from_data`

https://www.gnu.org/software/libmicrohttpd/manual/html_node/microhttpd_002dresponse-create.html

```
Function: struct MHD_Response * MHD_create_response_from_data (size_t size, void *data, int must_free, int must_copy)
Create a response object. The response object can be extended with header information and then it can be used any number of times. This function is deprecated, use MHD_create_response_from_buffer instead.
```